### PR TITLE
Ensure resulting array is flat in scratchGetAll

### DIFF
--- a/scratchon.js
+++ b/scratchon.js
@@ -214,7 +214,7 @@ scratchOn.scratchGetAll = async function (endpoint, id, part, method){
    var offset = 0;
    do {
       theseResults = await scratchOn.scratchGet(endpoint, id, part + "?offset=" + offset + "&limit=40", method);
-      results.push(theseResults);
+      results.push(...theseResults);
       offset++;
    } while(theseResults.length === 40);
    return results;


### PR DESCRIPTION
#2 specifies that the `Comment` was constructed, but the resulting object contained no meaningful data that pertained to the request.

Through debugging, it was concluded that the data being passed to the `Comment` constructor were 7 arguments which were all undefined, and the reason was determined.

The `that` object, from which all the relevant data was being extracted, was an *array*, not an object. It contained all the comments, not a singular piece of data as the loop was likely intending to extract. 

Further inspection yielded that the `things` array only contained one element, the aforementioned array of objects.

Hence, `things` looked like this:
```
[[{...}, {...}, {...}, {...}]]
```

And, `that` looked like this:
```
[{...}, {...}, {...}, {...}]
```

The cause of this was that `scratchOn.scratchGetAll` returned arrays of pages. Hence, the array was, by design, an array of arrays. This may have been useful in certain cases, but in this PR the choice has been to remove this functionality and thoroughly test each way `scratchOn.scratchGetAll` could be called.

It was verified that each of these paths work as they did before. If they didn't work before, and still don't, they've been marked with a red circle. If some of the problems have improved, a blue circle is used.

 - [X] `getAllRemixes` (to `scratchGetList`)
 - [X] `getAllStudios` (to `scratchGetList`)
 - [X] `getAllComments` (to `scratchGetList`)
 - [X] `getAllReplies` (to `scratchGetList`) 🔴 (error appears immediately instead of returning undefined now)
 - [X] User related methods 🔵 (see #4)

Closes #2 Closes #3 Towards #4