### PR TITLE
Fix getAll

### DIFF
--- a/scratchon.js
+++ b/scratchon.js
@@ -51,10 +51,10 @@ class Project {
       return {loved: lovedInfo.userLove,faved: favedInfo.userFavorite};
    }
    async getComments(offset,limit) {
-      return await scratchOn.scratchGetList(false, "comment", "/comments/project/", this.id, "?offset=" + (offset ? offset : 0) + "&limit=" + (limit ? limit : 40), "GET",{endpoint: "projects/",id: this.id});
+      return await scratchOn.scratchGetList(false, "comment", "/comments/project/", this.id, "?offset=" + (offset ? offset : 0) + "&limit=" + (limit ? limit : 40), "GET",{endpoint: "project/",id: this.id});
    }
    async getAllComments() {
-      return await scratchOn.scratchGetList(true, "comment", "/comments/project/", this.id, "", "GET",{endpoint: "projects/",id: this.id});
+      return await scratchOn.scratchGetList(true, "comment", "/comments/project/", this.id, "", "GET",{endpoint: "project/",id: this.id});
    }
 }
 class Studio {
@@ -215,7 +215,7 @@ scratchOn.scratchGetAll = async function (endpoint, id, part, method){
    do {
       theseResults = await scratchOn.scratchGet(endpoint, id, part + "?offset=" + offset + "&limit=40", method);
       results.push(...theseResults);
-      offset++;
+      offset += 40;
    } while(theseResults.length === 40);
    return results;
 }


### PR DESCRIPTION
### Fixes

Resolves #4 

### What this PR does
Changes the +1 to +40 because it was requesting way to many times. Also fixes a bug with getting comment replies.

### Testing

- [x] `user.getAllProjects()`
- [x] `user.getAllFollowers()`
- [x] `user.getAllFollowing()`
- [x] `user.getAllFavorites()` - oddly had a few more than the site thought, opening separate issue
- [x] `user.getAllStudiosCurating()` - oddly had a few more than the site thought, opening separate issue
- [x] `project.getAllStudios()`
- [x] `project.getAllRemixes()`
- [x] `project.getAllComments()`
- [x] `comment.getAllReplies()`